### PR TITLE
[#CHATEX-5] Clear text input after message sending

### DIFF
--- a/lib/chatbot_web/live/chat_live.ex
+++ b/lib/chatbot_web/live/chat_live.ex
@@ -8,7 +8,7 @@ defmodule ChatbotWeb.ChatLive do
     socket =
       socket
       |> assign(:messages, Chat.all_messages())
-      |> assign(:form, to_form(Chat.Message.changeset(%{role: :user, content: ""}), id: "0"))
+      |> assign(:form, build_form(0))
 
     {:ok, socket}
   end
@@ -70,10 +70,7 @@ defmodule ChatbotWeb.ChatLive do
     {:noreply,
      socket
      |> assign(:messages, messages)
-     |> assign(
-       :form,
-       to_form(Chat.Message.changeset(%{role: :user, content: ""}), id: "#{Enum.count(messages)}")
-     )}
+     |> assign(:form, build_form(Enum.count(messages)))}
   end
 
   @impl Phoenix.LiveView
@@ -112,5 +109,14 @@ defmodule ChatbotWeb.ChatLive do
     messages = [latest_assistant_message | messages] |> Enum.reverse()
 
     {:noreply, assign(socket, :messages, messages)}
+  end
+
+  defp build_form(id) do
+    %{role: :user, content: ""}
+    |> Chat.Message.changeset()
+    # we need to give the form an ID, so that
+    # PhoenixLiveView knows that this is a new form
+    # for a new message and clears the input
+    |> to_form(id: "message-#{id}")
   end
 end


### PR DESCRIPTION
To clear the input field after sending the message we can assign a new form with empty message field.
As we only make use of the `phx-submit` event (and not `phx-change`), the server state never has any content in the message.
That's why we must use a form_id to make it aware that something changed after assigning the new form with empty message.
See here: https://elixirforum.com/t/form-doesnt-always-get-cleared-after-submitting/65037

I think in a next step we could restructure the liveview form, so that we're not dealing with a map but with a changeset of a message instead.