### PR TITLE
Rag/rag transition 2

### DIFF
--- a/lib/chatbot/application.ex
+++ b/lib/chatbot/application.ex
@@ -10,12 +10,6 @@ defmodule Chatbot.Application do
     children = [
       {Nx.Serving,
        [
-         serving: Chatbot.Rag.Serving.build_llm_serving(),
-         name: Rag.LLMServing,
-         batch_timeout: 100
-       ]},
-      {Nx.Serving,
-       [
          serving: Chatbot.Rag.Serving.build_embedding_serving(),
          name: Rag.EmbeddingServing,
          batch_timeout: 100

--- a/lib/chatbot/rag.ex
+++ b/lib/chatbot/rag.ex
@@ -5,7 +5,7 @@ defmodule Chatbot.Rag do
   import Ecto.Query
   import Pgvector.Ecto.Query
 
-  @provider Ai.Nx.new(%{embeddings_serving: Rag.EmbeddingServing, text_serving: Rag.LLMServing})
+  @provider Ai.Nx.new(%{embeddings_serving: Rag.EmbeddingServing})
 
   def ingest(path) do
     path


### PR DESCRIPTION
# See [A RAG Library for Elixir](https://bitcrowd.dev/a-rag-library-for-elixir#build-your-rag-system)

We want to turn `chatbot_ex` into a RAG system that answers question about (ecto)[https://hex.pm/packages/ecto]. Out of the box, `chatbot_ex` knows nothing about ecto.

In [Step one](https://github.com/bitcrowd/chatbot_ex/pull/22), we ran the generator. 

## Removing the LLM serving

`chatbot_ex` is using [Ollama](https://ollama.com/) for text generation. Ollama is kind of a package manager for LLMs. It is easy to install and allows you to switch between [models](https://ollama.com/models) easily. Therefore, we can remove the `Nx.Serving` for text generation.

