### PR TITLE
Rag/rag transition 5

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -78,3 +78,23 @@
 );
 
 @use '~bitstyles/scss/bitstyles/utilities/z-index';
+
+.loader {
+  width: 1rem;
+  height: 1rem;
+  border: 5px solid #9485ff;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+  }
+
+  @keyframes rotation {
+  0% {
+      transform: rotate(0deg);
+  }
+  100% {
+      transform: rotate(360deg);
+  }
+} 

--- a/lib/chatbot/application.ex
+++ b/lib/chatbot/application.ex
@@ -25,6 +25,14 @@ defmodule Chatbot.Application do
       ChatbotWeb.Endpoint
     ]
 
+    :ok =
+      :telemetry.attach_many(
+        "rag-handler",
+        Rag.Telemetry.events(),
+        &Chatbot.Rag.TelemetryHandler.handle_event/4,
+        nil
+      )
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Chatbot.Supervisor]

--- a/lib/chatbot/rag/telemetry_handler.ex
+++ b/lib/chatbot/rag/telemetry_handler.ex
@@ -1,0 +1,8 @@
+defmodule Chatbot.Rag.TelemetryHandler do
+  alias Phoenix.PubSub
+
+  def handle_event(prefix, _measurement, _metadata, _config) do
+    [:rag, key, event] = prefix
+    PubSub.broadcast(Chatbot.PubSub, "rag", {key, event})
+  end
+end


### PR DESCRIPTION
# See [A RAG Library for Elixir](https://bitcrowd.dev/a-rag-library-for-elixir#build-your-rag-system)

We want to turn `chatbot_ex` into a RAG system that answers question about [`ecto`](https://hex.pm/packages/ecto). Out of the box, `chatbot_ex` knows nothing about `ecto`.

In [Step one](https://github.com/bitcrowd/chatbot_ex/pull/22), we ran the generator.
In [Step two](https://github.com/bitcrowd/chatbot_ex/pull/23), we removed the LLM serving as we will use Ollama to generate responses.
In [Step three](https://github.com/bitcrowd/chatbot_ex/pull/24), we set everything up to ingest `ecto` into our RAG system.
In [Step four](https://github.com/bitcrowd/chatbot_ex/pull/25), we integrated `rag` with `langchain`.

# Show Current Activity

As users, we want to see what our RAG system is doing while we wait for a response.
We add `telemetry` to the mix and use it to show the current activity to the user.